### PR TITLE
Fixed issue of sidebar covering content

### DIFF
--- a/src/Components/Navigation/SidePhoto.js
+++ b/src/Components/Navigation/SidePhoto.js
@@ -2,10 +2,11 @@ import { Show, Image, Box } from "@chakra-ui/react";
 
 const SidePhoto = () => {
   return (
-    <Show above="lg">
+    <Show above="xl">
       <Box
         mt="-16"
         right={0}
+        zIndex={-2}
         pos={"fixed"}
         borderLeft={"1px"}
         borderColor={"gray.700"}


### PR DESCRIPTION
The sidebar no longer covers the content- I changed the breakpoint to xl from lg, which allows the side bar to show up in a window that takes up most of a 13" screen. A good way to test this is messing around with screen width. The branch is called z index fixes, but it's really the breakpoint doing the heavy lifting. 