### PR TITLE
make AddJournal camera a bit sleeker

### DIFF
--- a/src/Components/Buttons/Slider.js
+++ b/src/Components/Buttons/Slider.js
@@ -16,7 +16,7 @@ function MoodSlider(props) {
   return (
     <Box p="8px" maxW="lg">
       <HStack justify={"left"} pb="8px">
-        <Text fontSize={"24px"} pb="4px">
+        <Text fontSize={["20px", "24px"]} pb="4px">
           how are you feeling?
         </Text>
         <Tooltip

--- a/src/Components/Camera.js
+++ b/src/Components/Camera.js
@@ -39,13 +39,7 @@ server error! we appologize for the inconvenience if so`
   return (
     <div>
       <Box maxW="450px" mx={10} align="center">
-        <Text
-          pb="10px"
-          ml="8px"
-          fontSize="32px"
-          fontStyle="italic"
-          align="start"
-        >
+        <Text pb="10px" ml="8px" fontSize={["20px", "24px"]} fontStyle="italic">
           snap a pic of your journal!
         </Text>
         {image === null ? (

--- a/src/Components/Journals/AddJournal.js
+++ b/src/Components/Journals/AddJournal.js
@@ -13,6 +13,7 @@ import {
   Show,
   HStack,
   IconButton,
+  useBreakpointValue,
 } from "@chakra-ui/react";
 import { AiOutlineCamera } from "react-icons/ai";
 import MoodSlider from "../Buttons/Slider";
@@ -57,6 +58,11 @@ const AddJournal = () => {
       throw error;
     }
   }
+
+  const placeholderText = useBreakpointValue({
+    base: "write your journal entry here or snap a pic of a handwritten page",
+    sm: "write your journal entry here or snap a pic of a handwritten page using your mobile device",
+  });
 
   return (
     <Stack px="24px" display="flex" maxW="3xl">
@@ -103,7 +109,7 @@ const AddJournal = () => {
           setJournal({ ...journal, content: evt.target.value })
         }
         resize="none"
-        placeholder="write your journal entry here or snap a pic of a pic of a handwritten page using your mobile device"
+        placeholder={placeholderText}
         aria-label="journal entry input field"
         size="lg"
         as={TextareaAutosize}

--- a/src/Components/Journals/AddJournal.js
+++ b/src/Components/Journals/AddJournal.js
@@ -11,8 +11,10 @@ import {
   Text,
   Textarea,
   Show,
-  Box,
+  HStack,
+  IconButton,
 } from "@chakra-ui/react";
+import { AiOutlineCamera } from "react-icons/ai";
 import MoodSlider from "../Buttons/Slider";
 import CheckConf from "./CheckConf";
 import TextareaAutosize from "react-textarea-autosize";
@@ -58,44 +60,8 @@ const AddJournal = () => {
 
   return (
     <Stack px="24px" display="flex" maxW="3xl">
-      <Show below="lg">
-        {showCamera ? (
-          <>
-            <Cam
-              setAllText={setAllText}
-              setModalLoading={setModalLoading}
-              modalLoading={modalLoading}
-              value={content}
-            />
-            {/* <Text pt="16px" ml="8px" fontSize={"24px"}>
-              change your mind?
-            </Text> */}
-            <br />
-            <Button
-              onClick={() => setShowCamera(false)}
-              variant="outline"
-              aria-label="close camera button"
-            >
-              close camera
-            </Button>
-          </>
-        ) : (
-          <>
-            <Text ml="8px" fontSize={"24px"}>
-              have a hand-written journal entry you want to add?
-            </Text>
-            <Button
-              onClick={() => setShowCamera(true)}
-              variant="outline"
-              aria-label="open camera button"
-            >
-              open camera
-            </Button>
-          </>
-        )}
-      </Show>
       {/* date input */}
-      <Text mt="32px" ml="8px" fontSize={"24px"}>
+      <Text mt="32px" ml="8px" fontSize={["20px", "24px"]}>
         date:
       </Text>
       <Input
@@ -106,16 +72,38 @@ const AddJournal = () => {
         onChange={(evt) => setJournal({ ...journal, date: evt.target.value })}
       />
       {/* content input */}
-      <Text mt="32px" pt="16px" ml="8px" fontSize={"24px"}>
-        what's going on?
-      </Text>
+      <HStack alignItems={"center"} mt="32px" pt="16px" ml="8px">
+        <Text ml="8px" fontSize={["20px", "24px"]}>
+          your journal entry:
+        </Text>
+        <Show below="lg">
+          <IconButton
+            variant={showCamera ? "solid" : "outline"}
+            size="md"
+            onClick={() => setShowCamera(!showCamera)}
+            aria-label="toggle camera button"
+            icon={<AiOutlineCamera />}
+          ></IconButton>
+        </Show>
+      </HStack>
+      {showCamera ? (
+        <>
+          <Cam
+            setAllText={setAllText}
+            setModalLoading={setModalLoading}
+            modalLoading={modalLoading}
+            value={content}
+          />
+          <br />
+        </>
+      ) : null}
       <Textarea
         value={content}
         onChange={(evt) =>
           setJournal({ ...journal, content: evt.target.value })
         }
         resize="none"
-        placeholder="write your journal entry here"
+        placeholder="write your journal entry here or snap a pic of a pic of a handwritten page using your mobile device"
         aria-label="journal entry input field"
         size="lg"
         as={TextareaAutosize}

--- a/src/Components/Moments/AddMoment.js
+++ b/src/Components/Moments/AddMoment.js
@@ -54,7 +54,7 @@ const AddMoment = () => {
   return (
     <>
       <Stack px="24px" display="flex" maxW="xl">
-        <Text pb="16px" mt="32px" ml="8px" fontSize={"24px"}>
+        <Text pb="16px" mt="32px" ml="8px" fontSize={["20px", "24px"]}>
           what's going on?
         </Text>
         <Textarea


### PR DESCRIPTION
This PR moves the "add from camera" functionality down a little bit into a camera icon button that is displayed alongside the writing prompt. You can toggle the camera by clicking the camera button, which eliminates the "close camera" button. This also resizes the fonts a bit when on mobile and changes a bit of language here and there.